### PR TITLE
Update CI workflow branches from 'develop' to 'dev'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to use the `dev` branch instead of `develop` for both push and pull request triggers. This ensures that continuous integration runs on the correct branch.

* CI workflow now triggers on the `dev` branch instead of `develop` for both push and pull request events in `.github/workflows/ci.yml`.